### PR TITLE
fix: add packages field to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+packages:
+  - '.'
+
 onlyBuiltDependencies:
   - dugite
+


### PR DESCRIPTION
Fix pnpm error `packages field missing or empty` by ensuring `pnpm-workspace.yaml` defines `packages`.